### PR TITLE
Add momentum conservation when bodies merge

### DIFF
--- a/src/graviton/sim.js
+++ b/src/graviton/sim.js
@@ -243,14 +243,16 @@ export default class GtSim {
         for (const body of bodies) {
             if (body.mass > largestMass) {
                 newBodyArgs.x = body.x;
-                newBodyArgs.y = body.y;
+                newBodyArgs.y = body.y;            
                 largestMass = body.mass;
             }
-            newBodyArgs.velX += body.velX;
-            newBodyArgs.velY += body.velY;
+            newBodyArgs.velX += body.mass*body.velX;
+            newBodyArgs.velY += body.mass*body.velY;   
             newBodyArgs.mass += body.mass;
             newBodyArgs.color = colors.blend(newBodyArgs.color, body.color);
         }
+        newBodyArgs.velX /= newBodyArgs.mass;
+        newBodyArgs.velY /= newBodyArgs.mass;        
 
         return this.addNewBody(newBodyArgs);
     }

--- a/src/graviton/sim.js
+++ b/src/graviton/sim.js
@@ -243,11 +243,11 @@ export default class GtSim {
         for (const body of bodies) {
             if (body.mass > largestMass) {
                 newBodyArgs.x = body.x;
-                newBodyArgs.y = body.y;            
+                newBodyArgs.y = body.y;
                 largestMass = body.mass;
             }
             newBodyArgs.velX += body.mass*body.velX;
-            newBodyArgs.velY += body.mass*body.velY;   
+            newBodyArgs.velY += body.mass*body.velY;
             newBodyArgs.mass += body.mass;
             newBodyArgs.color = colors.blend(newBodyArgs.color, body.color);
         }


### PR DESCRIPTION
It bothered me that a small body colliding a titan would make it fling away.  
It should be physically correct when considering the bodies colliding are a closed system, in a non-relativistic environment.
  
This does add some multiplications and divisions so it could cause performance problems. No performance degradation is apparent when trying on my computer, though.